### PR TITLE
fix: don't override highlights if already set

### DIFF
--- a/lua/lsp-lens/highlight.lua
+++ b/lua/lsp-lens/highlight.lua
@@ -2,16 +2,15 @@ local api = vim.api
 local M = {}
 
 local function default_hl()
-  return {
-    LspLens = { link = "Comment" },
-  }
+	return {
+		LspLens = { link = "Comment", default = true },
+	}
 end
 
 function M.setup()
-  for group, hl in pairs(default_hl()) do
-    api.nvim_set_hl(0, group, hl)
-  end
+	for group, hl in pairs(default_hl()) do
+		api.nvim_set_hl(0, group, hl)
+	end
 end
 
 return M
-


### PR DESCRIPTION
Currently if a colorscheme loads before the lsp-lens, then its highlight groups will be overridden