### PR TITLE
Fix already closing handler by remove unnecessary timer stop in do_request function

### DIFF
--- a/lua/lsp-lens/lens-util.lua
+++ b/lua/lsp-lens/lens-util.lua
@@ -170,7 +170,6 @@ local function do_request(symbols)
   local timer = vim.loop.new_timer()
   timer:start(0, 500, vim.schedule_wrap(function()
     if requests_done(finished) then
-      timer:stop()
       timer:close()
       display_lines(symbols.bufnr, functions)
       utils:set_buf_requesting(symbols.bufnr, 1)


### PR DESCRIPTION
![image_2023-03-12_13-56-36](https://user-images.githubusercontent.com/34479567/224545942-ed2ca7d0-fc89-43c3-a13f-47aa56027001.png)

I have already close handler error when using `lsp-lens.nvim`, I found code stop timer first and then close. I assumed that the stop function closes the timer and when we stop the timer, it gets stopped again.

So I tried to remove the stop code and it worked.

And I also found the latest document about it: https://neovim.io/doc/user/lua.html#lua-loop this example shows that we don't need timer:stop() anymore

```lua
-- Create a timer handle (implementation detail: uv_timer_t).
local timer = vim.loop.new_timer()
local i = 0
-- Waits 1000ms, then repeats every 750ms until timer:close().
timer:start(1000, 750, function()
  print('timer invoked! i='..tostring(i))
  if i > 4 then
    timer:close()  -- Always close handles to avoid leaks.
  end
  i = i + 1
end)
print('sleeping');
```
