### PR TITLE
Show lense info for items within an interface and Show lense information for Classes and Structs

### DIFF
--- a/lua/lsp-lens/lens-util.lua
+++ b/lua/lsp-lens/lens-util.lua
@@ -41,15 +41,26 @@ local SymbolKind = {
 local function get_functions(result)
   local ret = {}
   for _, v in pairs(result or {}) do
-    if v.kind == SymbolKind.Function or v.kind == SymbolKind.Methods or v.kind == SymbolKind.Interface then
+    local is_wrapper_structure = v.kind == SymbolKind.Class
+        or v.kind == SymbolKind.Struct
+        or v.kind == SymbolKind.Interface
+
+    if
+        v.kind == SymbolKind.Function
+        or v.kind == SymbolKind.Methods
+        or v.kind == SymbolKind.Interface
+        or is_wrapper_structure
+    then
       table.insert(ret, {
         name = v.name,
         rangeStart = v.range.start,
         selectionRangeStart = v.selectionRange.start,
         selectionRangeEnd = v.selectionRange["end"],
       })
-    elseif v.kind == SymbolKind.Class or v.kind == SymbolKind.Struct then
-      ret = utils:merge_table(ret, get_functions(v.children))   -- Recursively find methods
+    end
+
+    if is_wrapper_structure then
+      ret = utils:merge_table(ret, get_functions(v.children)) -- Recursively find methods
     end
   end
   return ret


### PR DESCRIPTION
In Java an interface can have methods within them. It would be helpful in my opinion to have these shown. I believe intellij does this as well:
<img width="374" alt="Screen Shot 2023-03-15 at 5 58 50 PM" src="https://user-images.githubusercontent.com/18195499/225461780-5a42b420-50b6-4105-8b87-519259d7461f.png">


It's also nice to see the code lense info for classes and I added the same for structs as well, although I don't have an example of a language that uses them:
<img width="382" alt="Screen Shot 2023-03-15 at 5 55 13 PM" src="https://user-images.githubusercontent.com/18195499/225461330-788455f9-7f37-4553-a1d3-1b81b19c9118.png">

