### PR TITLE
Protect against v.range being nil

### DIFF
--- a/lua/lsp-lens/lens-util.lua
+++ b/lua/lsp-lens/lens-util.lua
@@ -42,12 +42,14 @@ local function get_functions(result)
   local ret = {}
   for _, v in pairs(result or {}) do
     if v.kind == SymbolKind.Function or v.kind == SymbolKind.Methods or v.kind == SymbolKind.Interface then
-      table.insert(ret, {
-        name = v.name,
-        rangeStart = v.range.start,
-        selectionRangeStart = v.selectionRange.start,
-        selectionRangeEnd = v.selectionRange["end"],
-      })
+      if v.range and v.range.start then
+        table.insert(ret, {
+          name = v.name,
+          rangeStart = v.range.start,
+          selectionRangeStart = v.selectionRange.start,
+          selectionRangeEnd = v.selectionRange["end"],
+        })
+      end
     elseif v.kind == SymbolKind.Class or v.kind == SymbolKind.Struct then
       ret = utils:merge_table(ret, get_functions(v.children))   -- Recursively find methods
     end


### PR DESCRIPTION
Otherwise this error can be emitted:

```
Error executing vim.schedule lua callback: ...share/nvim/lazy/lsp-lens.nvim/lua/lsp-lens/lens-util.lua:47: attempt to index field 'range' (a nil value)
stack traceback:
        ...share/nvim/lazy/lsp-lens.nvim/lua/lsp-lens/lens-util.lua:47: in function 'get_functions'
        ...share/nvim/lazy/lsp-lens.nvim/lua/lsp-lens/lens-util.lua:61: in function 'get_cur_document_functions'
        ...share/nvim/lazy/lsp-lens.nvim/lua/lsp-lens/lens-util.lua:261: in function 'callback'
        ...w/Cellar/neovim/0.9.0/share/nvim/runtime/lua/vim/lsp.lua:2021: in function 'handler'
        ...w/Cellar/neovim/0.9.0/share/nvim/runtime/lua/vim/lsp.lua:1394: in function ''
        vim/_editor.lua: in function <vim/_editor.lua:0>
```