### PR TITLE
Allow target symbols for code lens to be configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ require'lsp-lens'.setup({})
 Below is the default config
 
 ```lua
+local SymbolKind = vim.lsp.protocol.SymbolKind
+
 require'lsp-lens'.setup({
   enable = true,
   include_declaration = false,      -- Reference include declaration
@@ -43,6 +45,10 @@ require'lsp-lens'.setup({
   ignore_filetype = {
     "prisma",
   },
+  -- Target Symbol Kinds to show lens information
+  target_symbol_kinds = { SymbolKind.Function, SymbolKind.Method, SymbolKind.Interface },
+  -- Symbol Kinds that may have target symbol kinds as children
+  wrapper_symbol_kinds = { SymbolKind.Class, SymbolKind.Struct },
 })
 ```
 

--- a/doc/lsp-lens-docs.txt
+++ b/doc/lsp-lens-docs.txt
@@ -51,6 +51,7 @@ CONFIGS                                  *lsp-lens-docs-lsp-lens.nvim-configs*
 Below is the default config
 
 >lua
+    local SymbolKind = vim.lsp.protocol.SymbolKind
     require'lsp-lens'.setup({
       enable = true,
       include_declaration = false,      -- Reference include declaration
@@ -63,6 +64,10 @@ Below is the default config
       ignore_filetype = {
         "prisma",
       },
+      -- Target Symbol Kinds to show lens information
+      target_symbol_kinds = { SymbolKind.Function, SymbolKind.Method, SymbolKind.Interface },
+      -- Symbol Kinds that may have target symbol kinds as children
+      wrapper_symbol_kinds = { SymbolKind.Class, SymbolKind.Struct },
     })
 <
 

--- a/lua/lsp-lens/config.lua
+++ b/lua/lsp-lens/config.lua
@@ -1,5 +1,7 @@
 local M = {}
 
+local SymbolKind = vim.lsp.protocol.SymbolKind
+
 local defaults = {
   enable = true,
   include_declaration = false, -- Reference include declaration
@@ -25,6 +27,10 @@ local defaults = {
   ignore_filetype = {
     "prisma",
   },
+  -- Target Symbol Kinds to show lens information
+  target_symbol_kinds = { SymbolKind.Function, SymbolKind.Method, SymbolKind.Interface },
+  -- Symbol Kinds that may have target symbol kinds as children
+  wrapper_symbol_kinds = { SymbolKind.Class, SymbolKind.Struct },
 }
 
 M.config = vim.deepcopy(defaults)

--- a/lua/lsp-lens/lens-util.lua
+++ b/lua/lsp-lens/lens-util.lua
@@ -35,19 +35,10 @@ local function requests_done(finished)
   return true
 end
 
--- enum
-local SymbolKind = {
-  Class = 5,
-  Methods = 6,
-  Interface = 11,
-  Function = 12,
-  Struct = 23,
-}
-
 local function get_functions(result)
   local ret = {}
   for _, v in pairs(result or {}) do
-    if v.kind == SymbolKind.Function or v.kind == SymbolKind.Methods or v.kind == SymbolKind.Interface then
+    if vim.tbl_contains(config.config.target_symbol_kinds, v.kind) then
       if v.range and v.range.start then
         table.insert(ret, {
           name = v.name,
@@ -57,7 +48,9 @@ local function get_functions(result)
           selectionRangeEnd = v.selectionRange["end"],
         })
       end
-    elseif v.kind == SymbolKind.Class or v.kind == SymbolKind.Struct then
+    end
+
+    if vim.tbl_contains(config.config.wrapper_symbol_kinds, v.kind) then
       ret = utils:merge_table(ret, get_functions(v.children)) -- Recursively find methods
     end
   end


### PR DESCRIPTION
This PR is to make it to where end users can configure which symbols they want to have code lens show up for.

This also allows a target to have code lens show up for itself and also have children that it shows a cod lens for like so:

![image](https://github.com/VidocqH/lsp-lens.nvim/assets/18195499/53fa8c4b-f91e-4afd-9a25-cf745b300021)