### PR TITLE
fix: prevent try to display lines on invalid buffer

### DIFF
--- a/lua/lsp-lens/lens-util.lua
+++ b/lua/lsp-lens/lens-util.lua
@@ -156,6 +156,9 @@ local function normalize_rangeStart_character(bufnr, query)
 end
 
 local function display_lines(bufnr, query_results)
+  if vim.fn.bufexists(bufnr) == 0 then
+    return
+  end
   local ns_id = vim.api.nvim_create_namespace("lsp-lens")
   delete_existing_lines(bufnr, ns_id)
   for _, query in pairs(query_results or {}) do


### PR DESCRIPTION
Maybe because this function is called in a timer, sometimes lsp-lens will report an invalid buffer error when a temporary buffer is closed.