### PR TITLE
close stdout after usage

### DIFF
--- a/lua/lsp-lens/lens-util.lua
+++ b/lua/lsp-lens/lens-util.lua
@@ -221,6 +221,7 @@ local function get_recent_editor(start_row, end_row, callback)
       end
     end
   end)
+  vim.loop.close(stdout)
 end
 
 local function do_request(symbols)


### PR DESCRIPTION
Fix #41,

Before fix, lsp-lens open a pipe for each symbol found without closing it. After a lot of git blame usage (by opening a lot of buffer or with huge buffer), pipes are cumulated and reach system limit.

This fix close each pipes after each usage. Pipes are not anymore cumulated.

With local test on a huge buffer, I have not any single more opened file compared with a usage without lsp-lens